### PR TITLE
Update themes to support urgency hint

### DIFF
--- a/themes/a-mego/lxqt-panel.qss
+++ b/themes/a-mego/lxqt-panel.qss
@@ -93,6 +93,11 @@ Plugin > QToolButton:hover{
    border: 1px solid #7f7f7f;
 }
 
+#TaskBar QToolButton[urgent="true"] {
+    color: palette(highlighted-text);
+    background: palette(highlight);
+}
+
 /*
  * Clock
  */

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -108,6 +108,11 @@ LxQtPanelPlugin > QToolButton:hover {
    border: 1px solid #7f7f7f;
 }
 
+#TaskBar QToolButton[urgent="true"] {
+    color: palette(highlighted-text);
+    background: palette(highlight);
+}
+
 /*
  * Clock
  */

--- a/themes/flat-dark-alpha/lxqt-panel.qss
+++ b/themes/flat-dark-alpha/lxqt-panel.qss
@@ -179,6 +179,11 @@ LxQtPanelPlugin > QToolButton:hover {
    background: rgba(255, 255, 255, 10%);
 }
 
+#TaskBar QToolButton[urgent="true"] {
+    color: palette(highlighted-text);
+    background: palette(highlight);
+}
+
 
 /*
  * Clock

--- a/themes/flat/lxqt-panel.qss
+++ b/themes/flat/lxqt-panel.qss
@@ -16,6 +16,11 @@ QToolTip {
 	margin: 0px;
 }
 
+#TaskBar QToolButton[urgent="true"] {
+    color: palette(highlighted-text);
+    background: palette(highlight);
+}
+
 
 QToolButton,
 TrayIcon,

--- a/themes/green/lxqt-panel.qss
+++ b/themes/green/lxqt-panel.qss
@@ -107,6 +107,11 @@ LxQtTaskButton {
     border: 1px solid #80a8d3;
 }
 
+#TaskBar QToolButton[urgent="true"] {
+    color: palette(highlighted-text);
+    background: palette(highlight);
+}
+
 /*
  * Clock
  */

--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -107,6 +107,11 @@ LxQtTaskButton {
     border: 1px solid #80a8d3;
 }
 
+#TaskBar QToolButton[urgent="true"] {
+    color: palette(highlighted-text);
+    background: palette(highlight);
+}
+
 /*
  * Clock
  */

--- a/themes/plasma-next-alpha/lxqt-panel.qss
+++ b/themes/plasma-next-alpha/lxqt-panel.qss
@@ -168,6 +168,11 @@ LxQtPanelPlugin > QToolButton {
    border-top: 3px solid #FF5C1F;
 }
 
+#TaskBar QToolButton[urgent="true"] {
+    color: palette(highlighted-text);
+    background: palette(highlight);
+}
+
 
 /*
  * Clock


### PR DESCRIPTION
Urgency hint color is always blue here, no matter what theme is active. Is this ok?

Fixes lxde/lxde-qt#231.
