### PR TITLE
Remove plugins' margins from themes files

### DIFF
--- a/themes/a-mego/lxqt-panel.qss
+++ b/themes/a-mego/lxqt-panel.qss
@@ -20,7 +20,7 @@ LxQtPanel[position="Top"] #BackgroundWidget {
  * General plugins settings
  */
 Plugin {
-    margin: 3px 0 3px 0;
+    margin: 0;
     padding: 0;
     spacing: 20px;
 }

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -22,7 +22,7 @@ LxQtPanel[position="Top"] #BackgroundWidget {
  */
 Plugin, 
 LxQtPanelPlugin {
-    margin: 2px 0 2px 0;
+    margin: 0;
     padding: 0;
     spacing: 20px;
     qproperty-moveMarkerColor: #C94C21;

--- a/themes/flat-dark-alpha/lxqt-panel.qss
+++ b/themes/flat-dark-alpha/lxqt-panel.qss
@@ -78,7 +78,7 @@ VolumePopup  > QSlider::sub-page:vertical {
 
 Plugin,
 LxQtPanelPlugin {
-    margin: 2px 0 2px 0;
+    margin: 0;
     padding: 0;
     spacing: 20px;
     qproperty-moveMarkerColor: #C94C21;

--- a/themes/green/lxqt-panel.qss
+++ b/themes/green/lxqt-panel.qss
@@ -29,7 +29,7 @@ LxQtPanel[position="Right"] #BackgroundWidget {
  * General plugins settings
  */
 Plugin {
-    padding: 0 2px 0 2px;
+    padding: 0;
     spacing: 20px;
 }
 

--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -29,7 +29,7 @@ LxQtPanel[position="Right"] #BackgroundWidget {
  * General plugins settings
  */
 Plugin {
-    padding: 0 2px 0 2px;
+    padding: 0;
     spacing: 20px;
 }
 

--- a/themes/plasma-next-alpha/lxqt-panel.qss
+++ b/themes/plasma-next-alpha/lxqt-panel.qss
@@ -75,7 +75,7 @@ VolumePopup  > QSlider::sub-page:vertical {
 
 Plugin,
 LxQtPanelPlugin {
-    margin: 2px 0 2px 0;
+    margin: 0;
     padding: 0;
     spacing: 20px;
     qproperty-moveMarkerColor: #C94C21;


### PR DESCRIPTION
So the user can use que panel edges to activate plugins. Fixes lxde/lxqt-panel#92.
