### PR TITLE
Restore the old preferences menu layout of razor-qt.

### DIFF
--- a/menu/desktop-directories/lxqt-settings.directory.in
+++ b/menu/desktop-directories/lxqt-settings.directory.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=Directory
+Name=LXQt settings
+Icon=preferences-system
+
+#TRANSLATIONS_DIR=translations
+
+# Translations

--- a/menu/lxqt-applications.menu
+++ b/menu/lxqt-applications.menu
@@ -151,22 +151,48 @@
 	<Menu>
 		<Name>DesktopSettings</Name>
 		<Directory>lxde-settings.directory</Directory>
+		<Menu>
+			<Name>LXQtSettings</Name>
+			<Directory>lxqt-settings.directory</Directory>
+			<Include>
+				<And>
+					<Category>LXQt</Category>
+					<Or>
+						<Category>Settings</Category>
+						<Category>PackageManager</Category>
+					</Or>
+				</And>
+				<!-- Include some optional components here -->
+				<Filename>obconf-qt.desktop</Filename>
+				<Filename>compton-conf.desktop</Filename>
+				<Filename>pcmanfm-qt-desktop-pref.desktop</Filename>
+			</Include>
+			<Layout>
+				<Filename>lxqt-config.desktop</Filename>
+				<Separator/>
+				<Merge type="menus"/>
+				<Merge type="files"/>
+			</Layout>
+		</Menu>
 		<OnlyUnallocated/>
 		<Include>
 			<Or>
 				<Category>Settings</Category>
 				<Category>PackageManager</Category>
-				<Category>System</Category>
 			</Or>
 		</Include>
+		<Exclude>
+			<Or>
+				<Filename>lxqt-config.desktop</Filename>
+			</Or>
+		</Exclude>
 		<Layout>
 			<Merge type="menus"/>
 			<Merge type="files"/>
 		</Layout>
-
 	</Menu> <!-- End Settings -->
 
-        <!-- Leave -->
+		<!-- Leave -->
 	<Menu>
 		<Name>X-Leave</Name>
 		<Directory>lxqt-leave.directory</Directory>


### PR DESCRIPTION
The "Preferences" menu is a little bit crowded now.
So I tried to restore the old menu layout of razor-qt.
Currently the newly added menu entry is in English.
I'll try to get that entry translated by using the translations in razor-qt.
@jleclanche @luis-pereira @paulolieuthier @pvanek @surlykke @agaida 
Please help review if this change is ok.
Thanks!