### PR TITLE
config: auto-detect succesfully kwin on recent kwin versions

### DIFF
--- a/config/windowmanagers.conf
+++ b/config/windowmanagers.conf
@@ -5,6 +5,9 @@ openbox/Comment=Light-weight window manager
 kwin/Name=KWin
 kwin/Comment=Window manager of the KDE Software Compilation
 
+kwin_x11/Name=KWin
+kwin_x11/Comment=Window manager of the KDE Software Compilation
+
 metacity/Name=Metacity
 metacity/Comment=Window manager of the GNOME desktop environment
 


### PR DESCRIPTION
Recently kde decided to split kwin's binary into two, kwin_x11 and
kwin_wayland in order to prepare the migration to wayland.

So to detect properly kwin on recent installations we need to look for
the binary kwin_x11 (and later kwin_wayland when LxQt gets ported to
wayland).

I've left the entry for kwin as it doesn't seem to interfere and allows
auto-detection of kwin to work on older intallations as well.

Fixes https://github.com/lxde/lxqt/issues/638