### PR TITLE
TryExec to detect proper installed lxqt-session

### DIFF
--- a/xsession/lxqt.desktop.in
+++ b/xsession/lxqt.desktop.in
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
 Exec=startlxqt
+TryExec=lxqt-session
 Name=LXQt Desktop
 Comment=Lightweight Qt Desktop
 


### PR DESCRIPTION
lxqt-session binary is installed from another module, but is referenced by startlxqt. Since common install the dm xsession entry, we should test to see if session is installed or not show at all, avoiding show in dm.