### PR TITLE
Fixes #807 – Add XDG_CACHE_HOME definition

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -30,6 +30,10 @@ if [ -z "$XDG_CONFIG_DIRS" ]; then
     export XDG_CONFIG_DIRS="@LXQT_ETC_XDG_DIR@"
 fi
 
+if [ -z "$XDG_CACHE_HOME" ]; then
+    export XDG_CACHE_HOME="$HOME/.cache"
+fi
+
 # Ensure the existance of the 'Desktop' folder
 if [ -e "$XDG_CONFIG_HOME/user-dirs.dirs" ]; then
     . "$XDG_CONFIG_HOME/user-dirs.dirs"


### PR DESCRIPTION
File “startlxqt.in” modified. Default value set accordingly to the
latest “XDG Base Directory Specification”, see
http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html