### PR TITLE
Add startlxqt man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ install(PROGRAMS
     DESTINATION "${CMAKE_INSTALL_BINDIR}"
     COMPONENT Runtime
 )
+install(FILES
+    startlxqt.1
+    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
+    COMPONENT Runtime
+)
 
 # default config files
 add_subdirectory(config)

--- a/startlxqt.1
+++ b/startlxqt.1
@@ -1,0 +1,48 @@
+.TH STARTLXQT 1 2015-11-03 "LXQt 0.10.0" "LXQt session management"
+.SH NAME
+startlxqt \- script to initialize and launch LXQt sessions
+.SH SYNOPSIS
+.B startlxqt
+.SH DESCRIPTION
+\fBstartlxqt\fR is a shell script meant to initialize and launch LXQt sessions.
+It is as such similar to counterparts of other desktop environments like startlxde in
+LXDE or startkde in KDE.
+.P
+It's main tasks are exporting environment variables, partly after performing
+corresponding checks, and launching \fBlxqt-session\fR, the LXQt session manager.
+.P
+It is not meant to be run by users.
+Rather, it is invoked as backend, e. g. by script \fBstartx\fR on virtual terminals or display
+managers like SDDM or LightDM, see section \fIEXAMPLE\fR.
+.SH FILES
+.I $XDG_DATA_DIRS/xsessions/lxqt.desktop
+.RS 5
+Desktop entry file stating startlxqt as binary needed to start LXQt sessions. Sourced e. g.
+by display managers.
+.RE
+.SH BUGS
+None at the time of this writing. Bugs can be reported on https://github.com/lxde/lxqt/issues.
+.SH EXAMPLE
+To start an LXQt session from a virtual terminal (virtual console) add a line
+.P
+.RS 5
+exec startlxqt
+.RE
+.P
+to file \fI~/.xinitrc\fR. An LXQt session will then be launched by running \fBstartx\fR.
+.P
+Display managers are making use of scripts like \fBstartlxqt\fR automatically. Information about
+available desktop environments is provided by files \fI$XDG_DATA_DIRS/xsessions/*.desktop\fR, typically
+\fI/usr/share/xessions/*.desktop\fR.
+.br
+File \fIlxqt.desktop\fR provided by LXQt is stating \fBstartlxqt\fR in key \fIExec\fR while making sure the session
+manager \fBlxqt-session\fR does exist by stating it in key \fITryExec\fR.
+.SH SEE ALSO
+.BR lxqt-session (1)
+.BR startx (1)
+.BR sddm (1)
+.P
+.B http://www.freedesktop.org/wiki/Specifications/desktop-entry-spec/
+.RS 5
+Desktop Entry Specification defining desktop entry files (*.desktop).
+.RE


### PR DESCRIPTION
Adds a man page for startlxqt as discussed in lxde/lxqt#864.

Not 100% sure about the change in CMakeLists.txt to get the man page built besides it seems to work. You may have another look.