### PR TITLE
lxqt-applications.menu: remove accidentally added topics from "System Tools"

### DIFF
--- a/menu/lxqt-applications.menu
+++ b/menu/lxqt-applications.menu
@@ -138,6 +138,9 @@
 				<Category>System</Category>
 				<Not><Category>Settings</Category></Not>
 				<Not><Category>PackageManager</Category></Not>
+				<Not><Category>X-Leave</Category></Not>
+				<Not><Category>Screensaver</Category></Not>
+				<Not><Filename>lxqt-about.desktop</Filename></Not>
 			</And>
 		</Include>
 	</Menu>	 <!-- End System Tools -->


### PR DESCRIPTION
In lxde/lxqt-session@898c2732 value `LXQt` in key `Categories` was exchanged with `System` in desktop entry files `lxqt-{hibernate,leave,lockscreen,logout,reboot,shutdown,suspend}` which belong to binary `lxqt-leave`. This was done in order to have `Categories` comprise a topic from the so called [Main Categories](http://standards.freedesktop.org/menu-spec/latest/apa.html#main-category-registry). This isn't stated as mandatory in the [corresponding section](http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html) of the [Desktop Entry Specification](http://standards.freedesktop.org/desktop-entry-spec/latest/index.html) but the lack makes binary `desktop-file-validate` throw warnings. Running `desktop-file-validate` is part of the standard packaging procedure in many distributions.
Both the exchange in general and selecting `System` seem the right thing to do but made those desktop entry files appear in "System Tools" in plugin-mainmenu, too.

This PR is proposing to solve the problem by excluding desktop entry files from "System Tools" if they are stating either value `X-Leave` or `Screensaver` in key `Categories`.

On a side note the problem apparently remained undiscovered for two months due to lxde/lxqt#65. At least on my systems it's only the changes due to lxde/lxqt-session@0ff7419 / lxde/lxqt-session@9f5b1c9 which made it become visible for whatever reasons.