### PR TITLE
icons: Add icon "lxqt"

### DIFF
--- a/icons/hicolor/scalable/apps/lxqt.svg
+++ b/icons/hicolor/scalable/apps/lxqt.svg
@@ -1,0 +1,1 @@
+../places/start-here-lxqt.svg


### PR DESCRIPTION
Just a link for "start-here-lxqt" to make it possible to force our icon
(if it is necessary). Almost all themes provides "start-here" icon and
this overrides "start-here-lxqt" in hicolor parent theme.

Spec: However, if the more specific item does not exist in the current
theme, and does exist in a parent theme, the generic icon from the
current theme is preferred, in order to keep consistent style.

This is needed by lxde/lxqt-notificationd#48