### PR TITLE
PCManFM-Qt: Sort in ascending order by default

### DIFF
--- a/config/pcmanfm-qt/lxqt/settings.conf.in
+++ b/config/pcmanfm-qt/lxqt/settings.conf.in
@@ -20,7 +20,7 @@ BgColor=#000000
 FgColor=#ffffff
 ShadowColor=#000000
 ShowHidden=false
-SortOrder=descending
+SortOrder=ascending
 SortColumn=name
 Font="Sans Serif,10,-1,5,50,0,0,0,0,0"
 
@@ -32,7 +32,7 @@ AutoRun=true
 [FolderView]
 Mode=icon
 ShowHidden=false
-SortOrder=descending
+SortOrder=ascending
 SortColumn=name
 BigIconSize=48
 SmallIconSize=24


### PR DESCRIPTION
Right now both FHS objects within the actual file manager and desktop objects are sorted in descending order on new user profiles according to directive `SortOrder` in sections`[Desktop]` and `[FolderView]` of PCManFM-Qt's `settings.ini`.
This PR is meant to change this order to ascending as it can be assumed this is what most users will expect.

On a side note I failed to see any effect of the said key in section `[Desktop]` so far.
Objects placed on an empty desktop seem to get sorted in descending order no matter whether `SortOrder` is set to `ascending` or `descending`.
@tsujan Any note on this, maybe?