### PR TITLE
PCManFM-Qt: Update default wallpaper

### DIFF
--- a/config/pcmanfm-qt/lxqt/settings.conf.in
+++ b/config/pcmanfm-qt/lxqt/settings.conf.in
@@ -15,7 +15,7 @@ ConfirmDelete=true
 
 [Desktop]
 WallpaperMode=stretch
-Wallpaper=@LXQT_SHARE_DIR@/themes/frost/numix.png
+Wallpaper=@LXQT_SHARE_DIR@/themes/frost/lxqt-origami-light.png
 BgColor=#000000
 FgColor=#ffffff
 ShadowColor=#000000


### PR DESCRIPTION
Fixes black background seen on new user profiles right now as the new
wallpaper introduced in default theme frost in lxde/lxqt-common@8c8786d
wasn't reflected in settings.conf of PCManFM-Qt so far.