### PR TITLE
Improves changed Openbox default path startup message

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -61,7 +61,7 @@ if [ ! -e "$XDG_CONFIG_HOME"/openbox/lxqt-rc.xml ] ; then
         if [ -d "$conf"/lxqt/openbox/ ] ; then
             echo "Default settings of openbox"
             cp -v "$conf"/lxqt/openbox/* "$XDG_CONFIG_HOME"/openbox/
-            xmessage "LXQt has changed Openbox default path." "If you want to keep your previous Openbox settings, run: \"cp ~/.config/openbox/rc.xml ~/.config/openbox/lxqt-rc.xml\"" &
+            printf "LXQt has changed Openbox default path.\nIf you want to keep your previous Openbox settings, run: \n\t\"cp ~/.config/openbox/rc.xml ~/.config/openbox/lxqt-rc.xml\"" | xmessage -center -title "LXQt Openbox default path" -file - &
         fi
     done
 fi


### PR DESCRIPTION
It:
    * Center the message
    * Adds an title
    * Improves formatting

I don't consider it a solution to https://github.com/lxde/lxqt/issues/1057. But in the meantime, at least, it's cleaner and easier to understand.
![screen-2016-05-23-20-11-47](https://cloud.githubusercontent.com/assets/62877/15481854/9469e256-2124-11e6-8376-ab09448ff293.png)
