### PR TITLE
Fix the search textfield style for all themes

### DIFF
--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -201,6 +201,29 @@ QCalendarWidget QAbstractItemView:enabled {
     background:qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #f88657, stop:1 #eb7140);
 }
 
+#MainMenu ActionView {
+    background-color: #3c3b37;
+    border: none;
+    color: #f2f1f0;
+}
+
+#MainMenu ActionView::item {
+    padding: 2px 0;
+}
+
+#MainMenu QLineEdit {
+    background: transparent;
+    border: none;
+    color: palette(highlighted-text);
+    margin-bottom: 1px;
+    padding: 6px;
+}
+
+#MainMenu QScrollBar::handle {
+    background-color: palette(highlighted-text);
+    color: palette(highlighted-text);
+}
+
 /*
  * QuickLaunch
  */

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -212,7 +212,7 @@ QCalendarWidget QAbstractItemView:enabled {
 }
 
 #MainMenu QLineEdit {
-    background: transparent;
+    background: #3c3b37;
     border: none;
     color: palette(highlighted-text);
     margin-bottom: 1px;

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -214,7 +214,7 @@ QCalendarWidget QAbstractItemView:enabled {
 #MainMenu QLineEdit {
     background: #3c3b37;
     border: none;
-    color: palette(highlighted-text);
+    color: #f2f1f0;
     margin-bottom: 1px;
     padding: 6px;
 }

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -286,7 +286,9 @@ TrayIcon {
 
 #MainMenu  QMenu {
     margin: 4px;
+    background: palette(text);
 }
+
 #MainMenu  QMenu::icon {
     background-color: transparent;
 }
@@ -305,7 +307,7 @@ TrayIcon {
 }
 
 #MainMenu QLineEdit {
-    background: transparent;
+    background: palette(text);
     border: none;
     padding: 6px;
     margin-bottom: 1px;
@@ -319,7 +321,7 @@ TrayIcon {
 }
 
 #MainMenu ActionView::item {
-    border: 1px solid transparent;
+    border: 1px solid palette(text);
     padding: 3px 0;
 }
 

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -286,7 +286,6 @@ TrayIcon {
 
 #MainMenu  QMenu {
     margin: 4px;
-    background-color: hsv(0, 0, 41);
 }
 #MainMenu  QMenu::icon {
     background-color: transparent;
@@ -305,9 +304,29 @@ TrayIcon {
     background: rgba(255, 255, 255, 20%);
 }
 
+#MainMenu QLineEdit {
+    background: transparent;
+    border: none;
+    padding: 6px;
+    margin-bottom: 1px;
+    color: palette(window);
+}
 
+#MainMenu ActionView {
+    border: none;
+    background: palette(text);
+    color: palette(window);
+}
 
+#MainMenu ActionView::item {
+    border: 1px solid transparent;
+    padding: 3px 0;
+}
 
+#MainMenu ActionView::item:selected, ActionView::item:hover {
+    background: palette(highlight);
+    color: palette(highlighted-text);
+}
 
 /*
  * Mount plugin

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -199,25 +199,22 @@ QCalendarWidget QSpinBox {
 }
 
 #MainMenu QLineEdit {
+    background: transparent;
     border: none;
-    margin: 10px;
-    padding: 3px;
-    background: palette(text);
+    padding: 6px;
+    margin-bottom: 1px;
     color: palette(window);
 }
 
 #MainMenu ActionView {
     border: none;
-    margin-right: 10px;
-    margin-left: 10px;
-    margin-top: 10px;
     background: palette(text);
     color: palette(window);
 }
 
 #MainMenu ActionView::item {
     border: 1px solid transparent;
-    padding: 5px;
+    padding: 3px 0;
 }
 
 #MainMenu ActionView::item:selected, ActionView::item:hover {

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -199,7 +199,7 @@ QCalendarWidget QSpinBox {
 }
 
 #MainMenu QLineEdit {
-    background: transparent;
+    background: palette(text);
     border: none;
     padding: 6px;
     margin-bottom: 1px;
@@ -213,7 +213,7 @@ QCalendarWidget QSpinBox {
 }
 
 #MainMenu ActionView::item {
-    border: 1px solid transparent;
+    border: 1px solid palette(text);
     padding: 3px 0;
 }
 

--- a/themes/kde-plasma/lxqt-panel.qss
+++ b/themes/kde-plasma/lxqt-panel.qss
@@ -87,6 +87,22 @@ QMenu::right-arrow {
     border-top: 3px solid #1E91FE;
 }
 
+#MainMenu QLineEdit {
+    background: transparent;
+    border: none;
+    padding: 6px;
+    margin-bottom: 1px;
+}
+
+#MainMenu ActionView {
+    background: palette(window);
+    border: none;
+}
+
+#MainMenu ActionView::item {
+    padding: 3px 0;
+}
+
 /*
  * TaskBar
  */

--- a/themes/kde-plasma/lxqt-panel.qss
+++ b/themes/kde-plasma/lxqt-panel.qss
@@ -88,7 +88,7 @@ QMenu::right-arrow {
 }
 
 #MainMenu QLineEdit {
-    background: transparent;
+    background: palette(window);
     border: none;
     padding: 6px;
     margin-bottom: 1px;

--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -178,6 +178,21 @@ TrayIcon {
     color: #EEEEEE;
 }
 
+#MainMenu ActionView {
+    background: palette(window);
+    border: 1px solid transparent;
+}
+
+#MainMenu ActionView::item {
+    padding: 2px 0;
+}
+
+#MainMenu QLineEdit {
+    background: transparent;
+    border: none;
+    padding: 6px;
+    margin-bottom: 1px;
+}
 
 /*
  * Mount plugin

--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -71,6 +71,31 @@ Plugin > QWidget > QToolButton:pressed {
 }
 
 /*
+ * Menus
+ */
+QMenu {
+    background: palette(window);
+    border: 1px solid #AAA;
+    border-radius: 2px;
+    color: palette(text);
+}
+
+QMenu::item {
+    color: palette(text);
+    padding: 5px 27px;
+}
+
+QMenu::item:selected {
+    background: palette(highlight);
+    color: palette(highlighted-text);
+}
+
+QMenu::icon {
+    border-color: 1px solid palette(window);
+    padding-left: 7px;
+}
+
+/*
  * Desktopswitch
  */
 #DesktopSwitch {}
@@ -180,7 +205,8 @@ TrayIcon {
 
 #MainMenu ActionView {
     background: palette(window);
-    border: 1px solid transparent;
+    border: none;
+    color: palette(text);
 }
 
 #MainMenu ActionView::item {
@@ -188,8 +214,9 @@ TrayIcon {
 }
 
 #MainMenu QLineEdit {
-    background: transparent;
+    background: palette(window);
     border: none;
+    color: palette(text);
     padding: 6px;
     margin-bottom: 1px;
 }


### PR DESCRIPTION
I simply made them transparent no better match the menu's colors. I adjusted the Frost theme for consistency. @intialonso: when you come back, propose new adjustments as you wish! :smile: 

![print1](https://cloud.githubusercontent.com/assets/1238157/16234765/d280413a-37a8-11e6-95bf-d614cc9733c6.png)
![print2](https://cloud.githubusercontent.com/assets/1238157/16234764/d27759d0-37a8-11e6-99fa-ad14df20e008.png)

Fixes lxde/lxqt#1006.