### PR TITLE
startlxqt: Copy existing openbox config preferably

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -8,7 +8,7 @@ install(FILES
     COMPONENT Runtime
 )
 install(DIRECTORY openbox
-    DESTINATION "${LXQT_ETC_XDG_DIR}/lxqt"
+    DESTINATION "${LXQT_ETC_XDG_DIR}"
     COMPONENT Runtime
 )
 

--- a/startlxqt.in
+++ b/startlxqt.in
@@ -55,15 +55,21 @@ if which dbus-launch >/dev/null && test -z "$DBUS_SESSION_BUS_ADDRESS"; then
 fi
 
 # Copy default settings of openbox
-if [ ! -e "$XDG_CONFIG_HOME"/openbox/lxqt-rc.xml ] ; then
-    mkdir -p "$XDG_CONFIG_HOME"/openbox/
-    for conf in `echo $XDG_CONFIG_DIRS|sed 's/:/\n/g'` ; do
-        if [ -d "$conf"/lxqt/openbox/ ] ; then
-            echo "Default settings of openbox"
-            cp -v "$conf"/lxqt/openbox/* "$XDG_CONFIG_HOME"/openbox/
-            printf "LXQt has changed Openbox default path.\nIf you want to keep your previous Openbox settings, run: \n\t\"cp ~/.config/openbox/rc.xml ~/.config/openbox/lxqt-rc.xml\"" | xmessage -center -title "LXQt Openbox default path" -file - &
-        fi
-    done
+if [ ! -e "$XDG_CONFIG_HOME/openbox/lxqt-rc.xml" ] ; then
+    if [ -e "$XDG_CONFIG_HOME/openbox/rc.xml" ]; then
+        #copy existing configuration of openbox
+        cp "$XDG_CONFIG_HOME/openbox/rc.xml" "$XDG_CONFIG_HOME/openbox/lxqt-rc.xml"
+        message="Your existing configuration for openbox '$XDG_CONFIG_HOME/openbox/rc.xml' was used to
+fill the LXQt's openbox configuration '$XDG_CONFIG_HOME/openbox/lxqt-rc.xml'.
+If you want to use the predefined LXQt's openbox configuration, run:
+  cp '@LXQT_ETC_XDG_DIR@/lxqt/openbox/lxqt-rc.xml' '$XDG_CONFIG_HOME/openbox'"
+        echo "$message" >&2
+        xmessage -center -title "LXQt Openbox configration" "$message" &
+    else
+        #copy our predefined configuration
+        mkdir -p "$XDG_CONFIG_HOME/openbox"
+        cp '@LXQT_ETC_XDG_DIR@/lxqt/openbox/lxqt-rc.xml' "$XDG_CONFIG_HOME/openbox"
+    fi
 fi
 
 # Qt4 platform plugin

--- a/startlxqt.in
+++ b/startlxqt.in
@@ -68,7 +68,7 @@ If you want to use the predefined LXQt's openbox configuration, run:
     else
         #copy our predefined configuration
         mkdir -p "$XDG_CONFIG_HOME/openbox"
-        cp '@LXQT_ETC_XDG_DIR@/lxqt/openbox/lxqt-rc.xml' "$XDG_CONFIG_HOME/openbox"
+        cp '@LXQT_ETC_XDG_DIR@/openbox/lxqt-rc.xml' "$XDG_CONFIG_HOME/openbox"
     fi
 fi
 


### PR DESCRIPTION
In case the lxqt-rc.xml does not exist, try to use rc.xml. Only if not
available copy our predefined configuration file.

This is good for backward compatibility. The new message looks like following:
![screenshot](https://cloud.githubusercontent.com/assets/10990929/16321792/35ae29e6-399f-11e6-8a98-65e43d31f7d0.png)

ref lxde/lxqt#1057