### PR TITLE
Openbox: Fix informational message about adoption of rc.xml

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -62,7 +62,7 @@ if [ ! -e "$XDG_CONFIG_HOME/openbox/lxqt-rc.xml" ] ; then
         message="Your existing configuration for openbox '$XDG_CONFIG_HOME/openbox/rc.xml' was used to
 fill the LXQt's openbox configuration '$XDG_CONFIG_HOME/openbox/lxqt-rc.xml'.
 If you want to use the predefined LXQt's openbox configuration, run:
-  cp '@LXQT_ETC_XDG_DIR@/lxqt/openbox/lxqt-rc.xml' '$XDG_CONFIG_HOME/openbox'"
+  cp '@LXQT_ETC_XDG_DIR@/openbox/lxqt-rc.xml' '$XDG_CONFIG_HOME/openbox'"
         echo "$message" >&2
         xmessage -center -title "LXQt Openbox configration" "$message" &
     else


### PR DESCRIPTION
Message informing about adoption of preexisting custom rc.xml of Openbox hadn't
been adjusted to modified path, see https://github.com/lxde/lxqt-common/pull/53#issuecomment-229207407.