### PR TITLE
build: Add xmessage as "dependency"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ include(LXQtTranslateDesktop)
 
 install(DIRECTORY "graphics/" DESTINATION "${LXQT_GRAPHICS_DIR}")
 
+# xmessage dependency - to notify packagers
+find_program(XMESSAGE xmessage PATHS ENV PATH NO_DEFAULT_PATH)
+if (NOT XMESSAGE)
+    message(SEND_ERROR "The run-time dependency of startlxt -> 'xmessage' is not found")
+endif()
+
 # startlxqt script
 set(PREDEF_XDG_DATA_DIRS "$XDG_DATA_HOME")
 if(NOT("${LXQT_DATA_DIR}" MATCHES "^/usr(/local)?/share$"))


### PR DESCRIPTION
Addressing the 

> Currently none of the LXQt components is depending on `xmessage`.
Should this be changed somehow?

from https://github.com/lxde/lxqt-common/pull/53#issuecomment-229207407