### PR TITLE
Don't load google website when launching web browser

### DIFF
--- a/config/globalkeyshortcuts.conf
+++ b/config/globalkeyshortcuts.conf
@@ -33,7 +33,7 @@ Exec=pcmanfm-qt
 [Control%2BAlt%2BI.7]
 Comment=Internet. Web browser.
 Enabled=true
-Exec=xdg-open, http://google.com
+Exec=x-www-browser
 
 [Print.8]
 Comment=screen shot


### PR DESCRIPTION
When launching web browser with short cut Ctrl+Alt+I i don't want to load google website or any other website. Just want to start the web browser.
I'm not sure if "x-www-browser" is the correct command to use but for me it works.