### PR TITLE
Update globalkeyshortcuts.conf

### DIFF
--- a/autostart/translations/lxqt-compton_da.desktop
+++ b/autostart/translations/lxqt-compton_da.desktop
@@ -1,0 +1,3 @@
+# Translations
+Name[da]=Compton (X-compositor)
+Comment[da]=En X-compositor

--- a/autostart/translations/lxqt-desktop_da_DK.desktop
+++ b/autostart/translations/lxqt-desktop_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=Skrivebord

--- a/autostart/translations/lxqt-globalkeyshortcuts_da.desktop
+++ b/autostart/translations/lxqt-globalkeyshortcuts_da.desktop
@@ -1,2 +1,2 @@
 # Translations
-Name[da]=Globale genvejstaster
+Name[da]=Globale tastaturgenveje

--- a/autostart/translations/lxqt-globalkeyshortcuts_da_DK.desktop
+++ b/autostart/translations/lxqt-globalkeyshortcuts_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=Globale genvejstaster

--- a/autostart/translations/lxqt-notifications_da.desktop
+++ b/autostart/translations/lxqt-notifications_da.desktop
@@ -1,2 +1,2 @@
 # Translations
-Name[da]=Beskedtjeneste
+Name[da]=Notifikationsbaggrundsprogram

--- a/autostart/translations/lxqt-notifications_da_DK.desktop
+++ b/autostart/translations/lxqt-notifications_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=Bekendtgørelse Tjeneste

--- a/autostart/translations/lxqt-panel_da_DK.desktop
+++ b/autostart/translations/lxqt-panel_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=Panel

--- a/autostart/translations/lxqt-policykit-agent_da.desktop
+++ b/autostart/translations/lxqt-policykit-agent_da.desktop
@@ -1,2 +1,2 @@
 # Translations
-Name[da]=Håndtering af retningslinier
+Name[da]=PolicyKit-håndtering

--- a/autostart/translations/lxqt-policykit-agent_da_DK.desktop
+++ b/autostart/translations/lxqt-policykit-agent_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=Politikhåndtering

--- a/autostart/translations/lxqt-powermanagement_da.desktop
+++ b/autostart/translations/lxqt-powermanagement_da.desktop
@@ -1,0 +1,2 @@
+# Translations
+Name[da]=Strømstyring

--- a/autostart/translations/lxqt-qlipper-autostart_da.desktop
+++ b/autostart/translations/lxqt-qlipper-autostart_da.desktop
@@ -1,2 +1,2 @@
 # Translations
-Name[da]=Klippebord
+Name[da]=Qlipper

--- a/autostart/translations/lxqt-qlipper-autostart_da_DK.desktop
+++ b/autostart/translations/lxqt-qlipper-autostart_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=Qlipper

--- a/autostart/translations/lxqt-qstardict-autostart_da.desktop
+++ b/autostart/translations/lxqt-qstardict-autostart_da.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da]=QStarDict

--- a/autostart/translations/lxqt-qstardict-autostart_da_DK.desktop
+++ b/autostart/translations/lxqt-qstardict-autostart_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=QStarDict

--- a/autostart/translations/lxqt-runner_da_DK.desktop
+++ b/autostart/translations/lxqt-runner_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=Programstarter

--- a/autostart/translations/lxqt-xscreensaver-autostart_da_DK.desktop
+++ b/autostart/translations/lxqt-xscreensaver-autostart_da_DK.desktop
@@ -1,2 +1,0 @@
-# Translations
-Name[da_DK]=XScreenSaver

--- a/config/globalkeyshortcuts.conf
+++ b/config/globalkeyshortcuts.conf
@@ -31,9 +31,9 @@ Enabled=true
 Exec=pcmanfm-qt
 
 [Control%2BAlt%2BI.7]
-Comment=Internet. Web browser.
+Comment=Web browser
 Enabled=true
-Exec=xdg-open, http://google.com
+Exec=x-www-browser
 
 [Print.8]
 Comment=screen shot

--- a/menu/translations/lxqt-leave_da.directory
+++ b/menu/translations/lxqt-leave_da.directory
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Leave
+Comment=Leave Session
+Icon=system-shutdown
+Type=Directory
+
+#TRANSLATIONS_DIR=../translations
+
+# Translations
+Name[da]=Afslut
+Comment[da]=Afslut session

--- a/menu/translations/lxqt-settings_da.directory
+++ b/menu/translations/lxqt-settings_da.directory
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=Directory
+Name=LXQt settings
+Icon=preferences-system
+
+#TRANSLATIONS_DIR=translations
+
+# Translations
+Name[da]=LXQt-indstillinger

--- a/xsession/translations/lxqt_da.desktop
+++ b/xsession/translations/lxqt_da.desktop
@@ -1,3 +1,3 @@
 # Translations
-Name[da]=LXQt Desktop
-Comment[da]=Qt Desktop Environment
+Name[da]=LXQt-skrivebord
+Comment[da]=Letvægts Qt-skrivebord

--- a/xsession/translations/lxqt_da_DK.desktop
+++ b/xsession/translations/lxqt_da_DK.desktop
@@ -1,3 +1,0 @@
-# Translations
-Name[da_DK]=LXQt Desktop
-Comment[da_DK]=Qt Desktop


### PR DESCRIPTION
Personally i would change "Internet. Web browser." to just "Web browser".
Then the short cut (Ctrl+Alt+I) could be changed to Ctrl+Alt+W.
That would also make it easier to type on a QWERTY layout at least using just one hand.