### PR TITLE
globalkeys: Open "empty" browser on activation

### DIFF
--- a/config/globalkeyshortcuts.conf
+++ b/config/globalkeyshortcuts.conf
@@ -33,7 +33,7 @@ Exec=pcmanfm-qt
 [Control%2BAlt%2BI.7]
 Comment=Web browser
 Enabled=true
-Exec=xdg-open, https://duckduckgo.com
+Exec=xdg-open, about:blank
 
 [Print.8]
 Comment=screen shot


### PR DESCRIPTION
Use (neutral) 'about:blank' URL to open the web browser -> to avoid
flames about propagation of any other (proprietary) web site.