### PR TITLE
startlxqt: Consider $XDG_RUNTIME_DIR/bus for DBus

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -52,8 +52,10 @@ if [ -z "$SAL_USE_VCLPLUGIN" ]; then
 fi
 
 # Launch DBus if needed
-if which dbus-launch >/dev/null && test -z "$DBUS_SESSION_BUS_ADDRESS"; then
-    eval "$(dbus-launch --sh-syntax --exit-with-session)"
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    if [ -z "$XDG_RUNTIME_DIR" ] || ! [ -S "$XDG_RUNTIME_DIR/bus" ] || ! [ -O "$XDG_RUNTIME_DIR/bus" ]; then
+        eval "$(dbus-launch --sh-syntax --exit-with-session)" || echo "startlxqt: error executing dbus-launch" >&2
+    fi
 fi
 
 # Copy default settings of openbox


### PR DESCRIPTION
There are now multiple ways how Dbus daemon is launched, we need to
consider it.

More details in:
- https://lists.debian.org/debian-devel/2016/08/msg00554.html
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=836113

Fixes lxde/lxqt#1239

---

This is a WIP, as I'm not 100% sure, if I understood that all correctly.
